### PR TITLE
"Refactor Home component to parse and save playlist data"

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export interface MediaProps {
+  videoUrl: string;
+  title: string;
+  logo: string;
+}


### PR DESCRIPTION
This pull request refactors the Home component to improve the parsing and saving of playlist data. It introduces a new interface `MediaProps` to represent media items with properties `videoUrl` and `title`. The `parseM3U` function has been updated to handle the new format of the playlist data. Additionally, the `saveCategoryToLocalStorage` function now accepts `MediaProps` objects instead of a string URL. The changes ensure better organization and handling of playlist data in the Home component.